### PR TITLE
Add basic caching to routes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -25,6 +25,7 @@ class WeGoBusMap < Sinatra::Base
     feed.entity.each do |entity|
       positions << entity
     end
+    cache_control :public, max_age: 10
     response.headers['content-type'] = 'application/json'
     positions.to_json
   end
@@ -36,6 +37,7 @@ class WeGoBusMap < Sinatra::Base
     feed.entity.each do |entity|
       updates << entity
     end
+    cache_control :public, max_age: 10
     response.headers['content-type'] = 'application/json'
     updates.to_json
   end
@@ -47,21 +49,25 @@ class WeGoBusMap < Sinatra::Base
     feed.entity.each do |entity|
       alerts << entity
     end
+    cache_control :public, max_age: 10
     response.headers['content-type'] = 'application/json'
     alerts.to_json
   end
 
   get '/gtfs/routes/:route_id.json' do
+    cache_control :public, max_age: 300
     response.headers['content-type'] = 'application/json'
     File.read(File.join(DATA_DIRECTORY, 'routes', "#{params['route_id']}.json"))
   end
 
   get '/gtfs/trips/:trip_id.json' do
+    cache_control :public, max_age: 300
     response.headers['content-type'] = 'application/json'
     File.read(File.join(DATA_DIRECTORY, 'trips', "#{params['trip_id']}.json"))
   end
 
   get '/gtfs/shapes/:shape_id.json' do
+    cache_control :public, max_age: 300
     response.headers['content-type'] = 'application/json'
     File.read(File.join(DATA_DIRECTORY, 'shapes', "#{params['shape_id']}.json"))
   end


### PR DESCRIPTION
Semi-related to #5

The static GTFS data isn't changing much, so we can set a fairly long cache expiration on those points. The realtime data is designed to only refresh onnce every 10 seconds, so lets enforce that serverside.