### PR TITLE
Cache realtime data locally 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bundle/
 vendor/
+cache/

--- a/app.rb
+++ b/app.rb
@@ -28,6 +28,7 @@ class WeGoBusMap < Sinatra::Base
   get '/gtfs/realtime/vehiclepositions.json' do
     cacheFile = File.join(CACHE_DIRECTORY, 'vehiclepositions.json')
     if File.exist?(cacheFile) and (Time.now - File.stat(cacheFile).mtime).to_i <= REALTIME_CACHE_TTL
+      cache_control :public, max_age: REALTIME_CACHE_TTL
       response.headers['content-type'] = 'application/json'
       return File.read(cacheFile)
     end
@@ -53,6 +54,7 @@ class WeGoBusMap < Sinatra::Base
   get '/gtfs/realtime/tripupdates.json' do
     cacheFile = File.join(CACHE_DIRECTORY, 'tripupdates.json')
     if File.exist?(cacheFile) and (Time.now - File.stat(cacheFile).mtime).to_i <= REALTIME_CACHE_TTL
+      cache_control :public, max_age: REALTIME_CACHE_TTL
       response.headers['content-type'] = 'application/json'
       return File.read(cacheFile)
     end
@@ -77,6 +79,7 @@ class WeGoBusMap < Sinatra::Base
   get '/gtfs/realtime/alerts.json' do
     cacheFile = File.join(CACHE_DIRECTORY, 'alerts.json')
     if File.exist?(cacheFile) and (Time.now - File.stat(cacheFile).mtime).to_i <= REALTIME_CACHE_TTL
+      cache_control :public, max_age: REALTIME_CACHE_TTL
       response.headers['content-type'] = 'application/json'
       return File.read(cacheFile)
     end

--- a/app.rb
+++ b/app.rb
@@ -15,7 +15,7 @@ class WeGoBusMap < Sinatra::Base
   ALERTS_URL = 'http://transitdata.nashvillemta.org/TMGTFSRealTimeWebService/alert/alerts.pb'.freeze
   DATA_DIRECTORY = File.join(__dir__, 'data', 'gtfs')
   CACHE_DIRECTORY = File.join(__dir__, 'cache')
-  REALTIME_CACHE_TTL = 10
+  REALTIME_CACHE_TTL = 5
   GTFS_STATIC_CACHE_TTL = 300
 
   # Set up cache directory

--- a/app.rb
+++ b/app.rb
@@ -4,6 +4,8 @@ require 'google/transit/gtfs-realtime.pb'
 require 'net/http'
 require 'uri'
 require 'gtfs_reader'
+require 'fileutils'
+require 'date'
 
 ##
 # WeGo Bus Map
@@ -12,12 +14,24 @@ class WeGoBusMap < Sinatra::Base
   TRIP_UPDATES_URL = 'http://transitdata.nashvillemta.org/TMGTFSRealTimeWebService/tripupdate/tripupdates.pb'.freeze
   ALERTS_URL = 'http://transitdata.nashvillemta.org/TMGTFSRealTimeWebService/alert/alerts.pb'.freeze
   DATA_DIRECTORY = File.join(__dir__, 'data', 'gtfs')
+  CACHE_DIRECTORY = File.join(__dir__, 'cache')
+  REALTIME_CACHE_TTL = 10
+  GTFS_STATIC_CACHE_TTL = 300
+
+  # Set up cache directory
+  FileUtils.mkdir_p CACHE_DIRECTORY
 
   get '/' do
     erb :index
   end
 
   get '/gtfs/realtime/vehiclepositions.json' do
+    cacheFile = File.join(CACHE_DIRECTORY, 'vehiclepositions.json')
+    if File.exist?(cacheFile) and (Time.now - File.stat(cacheFile).mtime).to_i <= REALTIME_CACHE_TTL
+      response.headers['content-type'] = 'application/json'
+      return File.read(cacheFile)
+    end
+
     positions = []
     data = Net::HTTP.get(URI.parse(VEHICLE_POSITIONS_URL))
     feed = Transit_realtime::FeedMessage.decode(data)
@@ -25,49 +39,79 @@ class WeGoBusMap < Sinatra::Base
     feed.entity.each do |entity|
       positions << entity
     end
-    cache_control :public, max_age: 10
+
+    File.open(cacheFile, 'w') do |f|
+      f.write positions.to_json
+      f.close
+    end
+
+    cache_control :public, max_age: REALTIME_CACHE_TTL
     response.headers['content-type'] = 'application/json'
     positions.to_json
   end
 
   get '/gtfs/realtime/tripupdates.json' do
+    cacheFile = File.join(CACHE_DIRECTORY, 'tripupdates.json')
+    if File.exist?(cacheFile) and (Time.now - File.stat(cacheFile).mtime).to_i <= REALTIME_CACHE_TTL
+      response.headers['content-type'] = 'application/json'
+      return File.read(cacheFile)
+    end
+
     updates = []
     data = Net::HTTP.get(URI.parse(TRIP_UPDATES_URL))
     feed = Transit_realtime::FeedMessage.decode(data)
     feed.entity.each do |entity|
       updates << entity
     end
-    cache_control :public, max_age: 10
+
+    File.open(cacheFile, 'w') do |f|
+      f.write updates.to_json
+      f.close
+    end
+
+    cache_control :public, max_age: REALTIME_CACHE_TTL
     response.headers['content-type'] = 'application/json'
     updates.to_json
   end
 
   get '/gtfs/realtime/alerts.json' do
+    cacheFile = File.join(CACHE_DIRECTORY, 'alerts.json')
+    if File.exist?(cacheFile) and (Time.now - File.stat(cacheFile).mtime).to_i <= REALTIME_CACHE_TTL
+      response.headers['content-type'] = 'application/json'
+      return File.read(cacheFile)
+    end
+
     alerts = []
     data = Net::HTTP.get(URI.parse(ALERTS_URL))
     feed = Transit_realtime::FeedMessage.decode(data)
     feed.entity.each do |entity|
       alerts << entity
     end
-    cache_control :public, max_age: 10
+
+    File.open(cacheFile, 'w') do |f|
+      f.write alerts.to_json
+      f.close
+    end
+
+    cache_control :public, max_age: REALTIME_CACHE_TTL
     response.headers['content-type'] = 'application/json'
     alerts.to_json
   end
 
   get '/gtfs/routes/:route_id.json' do
-    cache_control :public, max_age: 300
+    cache_control :public, max_age: GTFS_STATIC_CACHE_TTL
     response.headers['content-type'] = 'application/json'
     File.read(File.join(DATA_DIRECTORY, 'routes', "#{params['route_id']}.json"))
   end
 
   get '/gtfs/trips/:trip_id.json' do
-    cache_control :public, max_age: 300
+    cache_control :public, max_age: GTFS_STATIC_CACHE_TTL
     response.headers['content-type'] = 'application/json'
     File.read(File.join(DATA_DIRECTORY, 'trips', "#{params['trip_id']}.json"))
   end
 
   get '/gtfs/shapes/:shape_id.json' do
-    cache_control :public, max_age: 300
+    cache_control :public, max_age: GTFS_STATIC_CACHE_TTL
     response.headers['content-type'] = 'application/json'
     File.read(File.join(DATA_DIRECTORY, 'shapes', "#{params['shape_id']}.json"))
   end


### PR DESCRIPTION
Fixes #5

Prior to this PR, every client that connected to the application would result in a hit to the API every 10 seconds, multiplied out by however many users are on the site. This change introduces a local file cache that will return that cached version for every request within the same 5 second window. In effect, we should never be hitting the API more than six times a minute, no matter the load on the site.